### PR TITLE
Added Machine Readable Visa A & B Support

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -6,6 +6,8 @@ const formats = {
   TD3: 'TD3',
   SWISS_DRIVING_LICENSE: 'SWISS_DRIVING_LICENSE',
   FRENCH_NATIONAL_ID: 'FRENCH_NATIONAL_ID',
+  MRVA: 'MRVA',
+  MRVB: 'MRVB',
 };
 Object.freeze(formats);
 

--- a/src/parse/__tests__/mrva.js
+++ b/src/parse/__tests__/mrva.js
@@ -63,7 +63,7 @@ describe('parse MRV-A', () => {
   it('GBR Example', () => {
     const MRZ = [
       'VBGBROCONNOR<<ENYA<SIOBHAN<<<<<<<<<<<<<<<<<<',
-      '5114278475DOM7510223M1506118<<<<<<<<<<<<<<08',
+      '5114278475DOM7510223M150611808<<<<<<<<<<<<<<',
     ];
 
     const result = parse(MRZ);
@@ -81,7 +81,7 @@ describe('parse MRV-A', () => {
       sex: 'male',
       expirationDate: '150611',
       expirationDateCheckDigit: '8',
-      optionalData: '              08',
+      optionalData: '08',
     });
   });
 });

--- a/src/parse/__tests__/mrva.js
+++ b/src/parse/__tests__/mrva.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const parse = require('../parse');
+
+describe('parse MRV-A', () => {
+  it('Utopia example', function () {
+    const MRZ = [
+      'V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<',
+      'L898902C<3UTO6908061F9406236ZE184226B<<<<<<<',
+    ];
+
+    const result = parse(MRZ);
+    expect(result).toMatchObject({
+      valid: false,
+      format: 'MRVA',
+    });
+    expect(result.valid).toBe(false);
+    const errors = result.details.filter((a) => !a.valid);
+    expect(errors).toHaveLength(2);
+    expect(result.fields).toStrictEqual({
+      documentCode: 'V',
+      firstName: 'ANNA MARIA',
+      lastName: 'ERIKSSON',
+      documentNumber: 'L898902C',
+      documentNumberCheckDigit: '3',
+      nationality: null,
+      sex: 'female',
+      expirationDate: '940623',
+      expirationDateCheckDigit: '6',
+      birthDate: '690806',
+      birthDateCheckDigit: '1',
+      issuingState: null,
+      optionalData: 'ZE184226B',
+    });
+
+    const personalNumberDetails = result.details.find(
+      (d) => d.field === 'optionalData',
+    );
+    expect(personalNumberDetails).toStrictEqual({
+      label: 'Optional data',
+      field: 'optionalData',
+      value: 'ZE184226B',
+      valid: true,
+      ranges: [{ line: 1, start: 28, end: 44, raw: 'ZE184226B<<<<<<<' }],
+      line: 1,
+      start: 28,
+      end: 37,
+    });
+
+    expect(errors[0]).toStrictEqual({
+      label: 'Issuing state',
+      field: 'issuingState',
+      value: null,
+      valid: false,
+      ranges: [{ line: 0, start: 2, end: 5, raw: 'UTO' }],
+      line: 0,
+      start: 2,
+      end: 5,
+      error: 'invalid state code: UTO',
+    });
+  });
+
+  it('GBR Example', () => {
+    const MRZ = [
+      'VBGBROCONNOR<<ENYA<SIOBHAN<<<<<<<<<<<<<<<<<<',
+      '5114278475DOM7510223M1506118<<<<<<<<<<<<<<08',
+    ];
+
+    const result = parse(MRZ);
+    expect(result.valid).toBe(true);
+    expect(result.fields).toStrictEqual({
+      documentCode: 'VB',
+      issuingState: 'GBR',
+      lastName: 'OCONNOR',
+      firstName: 'ENYA SIOBHAN',
+      documentNumber: '511427847',
+      documentNumberCheckDigit: '5',
+      nationality: 'DOM',
+      birthDate: '751022',
+      birthDateCheckDigit: '3',
+      sex: 'male',
+      expirationDate: '150611',
+      expirationDateCheckDigit: '8',
+      optionalData: '              08',
+    });
+  });
+});

--- a/src/parse/__tests__/mrva.js
+++ b/src/parse/__tests__/mrva.js
@@ -33,10 +33,10 @@ describe('parse MRV-A', () => {
       optionalData: 'ZE184226B',
     });
 
-    const personalNumberDetails = result.details.find(
+    const optionalDataDetails = result.details.find(
       (d) => d.field === 'optionalData',
     );
-    expect(personalNumberDetails).toStrictEqual({
+    expect(optionalDataDetails).toStrictEqual({
       label: 'Optional data',
       field: 'optionalData',
       value: 'ZE184226B',
@@ -82,6 +82,20 @@ describe('parse MRV-A', () => {
       expirationDate: '150611',
       expirationDateCheckDigit: '8',
       optionalData: '08',
+    });
+
+    const optionalDataDetails = result.details.find(
+      (d) => d.field === 'optionalData',
+    );
+    expect(optionalDataDetails).toStrictEqual({
+      label: 'Optional data',
+      field: 'optionalData',
+      value: '08',
+      valid: true,
+      ranges: [{ line: 1, start: 28, end: 44, raw: '08<<<<<<<<<<<<<<' }],
+      line: 1,
+      start: 28,
+      end: 30,
     });
   });
 });

--- a/src/parse/__tests__/mrvb.js
+++ b/src/parse/__tests__/mrvb.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const parse = require('../parse');
+
+describe('parse MRV-B', () => {
+  it('Utopia example', function () {
+    const MRZ = [
+      'V<UTOHENG<<DEBORAH<MING<LO<<<<<<<<<<',
+      'L8988901C4XXX4009078F9612109<<<<<<<<',
+    ];
+
+    const result = parse(MRZ);
+    expect(result).toMatchObject({
+      valid: false,
+      format: 'MRVB',
+    });
+    expect(result.valid).toBe(false);
+    const errors = result.details.filter((a) => !a.valid);
+    expect(errors).toHaveLength(1);
+    expect(result.fields).toStrictEqual({
+      documentCode: 'V',
+      firstName: 'DEBORAH MING LO',
+      lastName: 'HENG',
+      documentNumber: 'L8988901C',
+      documentNumberCheckDigit: '4',
+      nationality: 'XXX',
+      sex: 'female',
+      expirationDate: '961210',
+      expirationDateCheckDigit: '9',
+      birthDate: '400907',
+      birthDateCheckDigit: '8',
+      issuingState: null,
+      optionalData: '',
+    });
+
+    const personalNumberDetails = result.details.find(
+      (d) => d.field === 'nationality',
+    );
+    expect(personalNumberDetails).toStrictEqual({
+      label: 'Nationality',
+      field: 'nationality',
+      value: 'XXX',
+      valid: true,
+      ranges: [{ line: 1, start: 10, end: 13, raw: 'XXX' }],
+      line: 1,
+      start: 10,
+      end: 13,
+    });
+  });
+
+  it('Hyphenated name', () => {
+    const MRZ = [
+      'V<FINSMITH<JONES<<SUSIE<MARGARET<<<<',
+      'L898902C<3USA6908061F9406236ZE184226',
+    ];
+
+    const result = parse(MRZ);
+    expect(result).toMatchObject({
+      valid: true,
+      format: 'MRVB',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.fields).toStrictEqual({
+      documentCode: 'V',
+      issuingState: 'FIN',
+      lastName: 'SMITH JONES',
+      firstName: 'SUSIE MARGARET',
+      documentNumber: 'L898902C',
+      documentNumberCheckDigit: '3',
+      nationality: 'USA',
+      birthDate: '690806',
+      birthDateCheckDigit: '1',
+      sex: 'female',
+      expirationDate: '940623',
+      expirationDateCheckDigit: '6',
+      optionalData: 'ZE184226',
+    });
+  });
+});

--- a/src/parse/__tests__/mrvb.js
+++ b/src/parse/__tests__/mrvb.js
@@ -48,7 +48,7 @@ describe('parse MRV-B', () => {
     });
   });
 
-  it('Finland visa', () => {
+  it('Finland visa optional data', () => {
     const MRZ = [
       'V<FINSMITH<JONES<<SUSIE<MARGARET<<<<',
       'L898902C<3USA6908061F9406236ZE184226',
@@ -74,6 +74,20 @@ describe('parse MRV-B', () => {
       expirationDate: '940623',
       expirationDateCheckDigit: '6',
       optionalData: 'ZE184226',
+    });
+
+    const personalNumberDetails = result.details.find(
+      (d) => d.field === 'optionalData',
+    );
+    expect(personalNumberDetails).toStrictEqual({
+      label: 'Optional data',
+      field: 'optionalData',
+      value: 'ZE184226',
+      valid: true,
+      ranges: [{ line: 1, start: 28, end: 36, raw: 'ZE184226' }],
+      line: 1,
+      start: 28,
+      end: 36,
     });
   });
 });

--- a/src/parse/__tests__/mrvb.js
+++ b/src/parse/__tests__/mrvb.js
@@ -33,18 +33,18 @@ describe('parse MRV-B', () => {
       optionalData: '',
     });
 
-    const personalNumberDetails = result.details.find(
-      (d) => d.field === 'nationality',
+    const optionalDataDetails = result.details.find(
+      (d) => d.field === 'optionalData',
     );
-    expect(personalNumberDetails).toStrictEqual({
-      label: 'Nationality',
-      field: 'nationality',
-      value: 'XXX',
+    expect(optionalDataDetails).toStrictEqual({
+      label: 'Optional data',
+      field: 'optionalData',
+      value: '',
       valid: true,
-      ranges: [{ line: 1, start: 10, end: 13, raw: 'XXX' }],
+      ranges: [{ line: 1, start: 28, end: 36, raw: '<<<<<<<<' }],
       line: 1,
-      start: 10,
-      end: 13,
+      start: 28,
+      end: 28,
     });
   });
 
@@ -76,10 +76,10 @@ describe('parse MRV-B', () => {
       optionalData: 'ZE184226',
     });
 
-    const personalNumberDetails = result.details.find(
+    const optionalDataDetails = result.details.find(
       (d) => d.field === 'optionalData',
     );
-    expect(personalNumberDetails).toStrictEqual({
+    expect(optionalDataDetails).toStrictEqual({
       label: 'Optional data',
       field: 'optionalData',
       value: 'ZE184226',

--- a/src/parse/__tests__/mrvb.js
+++ b/src/parse/__tests__/mrvb.js
@@ -48,7 +48,7 @@ describe('parse MRV-B', () => {
     });
   });
 
-  it('Hyphenated name', () => {
+  it('Finland visa', () => {
     const MRZ = [
       'V<FINSMITH<JONES<<SUSIE<MARGARET<<<<',
       'L898902C<3USA6908061F9406236ZE184226',

--- a/src/parse/mrva.js
+++ b/src/parse/mrva.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { MRVA } = require('../formats');
+
+const checkLines = require('./checkLines');
+const getResult = require('./getResult');
+const mrvaFields = require('./mrvaFields');
+
+module.exports = function parseMRVA(lines) {
+  lines = checkLines(lines);
+  if (lines.length !== 2) {
+    throw new Error(
+      `invalid number of lines: ${lines.length}: Must be 2 for ${MRVA}`,
+    );
+  }
+  lines.forEach((line, index) => {
+    if (line.length !== 44) {
+      throw new Error(
+        `invalid number of characters for line ${index + 1}: ${
+          line.length
+        }. Must be 44 for MRVA`,
+      );
+    }
+  });
+  return getResult(MRVA, lines, mrvaFields);
+};

--- a/src/parse/mrvaFields.js
+++ b/src/parse/mrvaFields.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const parseDocumentCode = require('../parsers/parseDocumentCodeVisa');
+const parseOptional = require('../parsers/parseOptional');
+
+const createFieldParser = require('./createFieldParser');
+const {
+  documentCodeTemplate,
+  issuingStateTemplate,
+  lastNameTemplate,
+  firstNameTemplate,
+  documentNumberTemplate,
+  documentNumberCheckDigitTemplate,
+  nationalityTemplate,
+  birthDateTemplate,
+  birthDateCheckDigitTemplate,
+  sexTemplate,
+  expirationDateTemplate,
+  expirationDateCheckDigitTemplate,
+} = require('./fieldTemplates');
+
+module.exports = [
+  Object.assign({}, documentCodeTemplate, {
+    line: 0,
+    start: 0,
+    end: 2,
+    parser: parseDocumentCode,
+  }),
+  Object.assign({}, issuingStateTemplate, {
+    line: 0,
+    start: 2,
+    end: 5,
+  }),
+  Object.assign({}, lastNameTemplate, {
+    line: 0,
+    start: 5,
+    end: 44,
+  }),
+  Object.assign({}, firstNameTemplate, {
+    line: 0,
+    start: 5,
+    end: 44,
+  }),
+  Object.assign({}, documentNumberTemplate, {
+    line: 1,
+    start: 0,
+    end: 9,
+  }),
+  Object.assign({}, documentNumberCheckDigitTemplate, {
+    line: 1,
+    start: 9,
+    end: 10,
+    related: [
+      {
+        line: 1,
+        start: 0,
+        end: 9,
+      },
+    ],
+  }),
+  Object.assign({}, nationalityTemplate, {
+    line: 1,
+    start: 10,
+    end: 13,
+  }),
+  Object.assign({}, birthDateTemplate, {
+    line: 1,
+    start: 13,
+    end: 19,
+  }),
+  Object.assign({}, birthDateCheckDigitTemplate, {
+    line: 1,
+    start: 19,
+    end: 20,
+    related: [
+      {
+        line: 1,
+        start: 13,
+        end: 19,
+      },
+    ],
+  }),
+  Object.assign({}, sexTemplate, {
+    line: 1,
+    start: 20,
+    end: 21,
+  }),
+  Object.assign({}, expirationDateTemplate, {
+    line: 1,
+    start: 21,
+    end: 27,
+  }),
+  Object.assign({}, expirationDateCheckDigitTemplate, {
+    line: 1,
+    start: 27,
+    end: 28,
+    related: [
+      {
+        line: 1,
+        start: 21,
+        end: 27,
+      },
+    ],
+  }),
+  {
+    label: 'Optional data',
+    field: 'optionalData',
+    line: 1,
+    start: 28,
+    end: 44,
+    parser: parseOptional,
+  },
+].map(createFieldParser);

--- a/src/parse/mrvb.js
+++ b/src/parse/mrvb.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { MRVB } = require('../formats');
+
+const checkLines = require('./checkLines');
+const getResult = require('./getResult');
+const mrvbFields = require('./mrvbFields');
+
+module.exports = function parseMRVA(lines) {
+  lines = checkLines(lines);
+  if (lines.length !== 2) {
+    throw new Error(
+      `invalid number of lines: ${lines.length}: Must be 2 for ${MRVB}`,
+    );
+  }
+  lines.forEach((line, index) => {
+    if (line.length !== 36) {
+      throw new Error(
+        `invalid number of characters for line ${index + 1}: ${
+          line.length
+        }. Must be 36 for MRVB`,
+      );
+    }
+  });
+  return getResult(MRVB, lines, mrvbFields);
+};

--- a/src/parse/mrvbFields.js
+++ b/src/parse/mrvbFields.js
@@ -103,7 +103,7 @@ module.exports = [
     ],
   }),
   {
-    label: 'Optional Data',
+    label: 'Optional data',
     field: 'optionalData',
     line: 1,
     start: 28,

--- a/src/parse/mrvbFields.js
+++ b/src/parse/mrvbFields.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const parseDocumentCode = require('../parsers/parseDocumentCodeVisa');
+const parseOptional = require('../parsers/parseOptional');
+
+const createFieldParser = require('./createFieldParser');
+const {
+  documentCodeTemplate,
+  issuingStateTemplate,
+  lastNameTemplate,
+  firstNameTemplate,
+  documentNumberTemplate,
+  documentNumberCheckDigitTemplate,
+  nationalityTemplate,
+  birthDateTemplate,
+  birthDateCheckDigitTemplate,
+  sexTemplate,
+  expirationDateTemplate,
+  expirationDateCheckDigitTemplate,
+} = require('./fieldTemplates');
+
+module.exports = [
+  Object.assign({}, documentCodeTemplate, {
+    line: 0,
+    start: 0,
+    end: 2,
+    parser: parseDocumentCode,
+  }),
+  Object.assign({}, issuingStateTemplate, {
+    line: 0,
+    start: 2,
+    end: 5,
+  }),
+  Object.assign({}, lastNameTemplate, {
+    line: 0,
+    start: 5,
+    end: 36,
+  }),
+  Object.assign({}, firstNameTemplate, {
+    line: 0,
+    start: 5,
+    end: 36,
+  }),
+  Object.assign({}, documentNumberTemplate, {
+    line: 1,
+    start: 0,
+    end: 9,
+  }),
+  Object.assign({}, documentNumberCheckDigitTemplate, {
+    line: 1,
+    start: 9,
+    end: 10,
+    related: [
+      {
+        line: 1,
+        start: 0,
+        end: 9,
+      },
+    ],
+  }),
+  Object.assign({}, nationalityTemplate, {
+    line: 1,
+    start: 10,
+    end: 13,
+  }),
+  Object.assign({}, birthDateTemplate, {
+    line: 1,
+    start: 13,
+    end: 19,
+  }),
+  Object.assign({}, birthDateCheckDigitTemplate, {
+    line: 1,
+    start: 19,
+    end: 20,
+    related: [
+      {
+        line: 1,
+        start: 13,
+        end: 19,
+      },
+    ],
+  }),
+  Object.assign({}, sexTemplate, {
+    line: 1,
+    start: 20,
+    end: 21,
+  }),
+  Object.assign({}, expirationDateTemplate, {
+    line: 1,
+    start: 21,
+    end: 27,
+  }),
+  Object.assign({}, expirationDateCheckDigitTemplate, {
+    line: 1,
+    start: 27,
+    end: 28,
+    related: [
+      {
+        line: 1,
+        start: 21,
+        end: 27,
+      },
+    ],
+  }),
+  {
+    label: 'Optional Data',
+    field: 'optionalData',
+    line: 1,
+    start: 28,
+    end: 36,
+    parser: parseOptional,
+  },
+].map(createFieldParser);

--- a/src/parse/parse.js
+++ b/src/parse/parse.js
@@ -17,12 +17,18 @@ function parseMRZ(lines) {
           const endLine1 = lines[0].substr(30, 36);
           if (endLine1.match(/[0-9]/)) {
             return parsers.FRENCH_NATIONAL_ID(lines);
+          } else if (lines[0].charAt(0) === 'V') {
+            return parsers.MRVB(lines);
           } else {
             return parsers.TD2(lines);
           }
         }
         case 44:
-          return parsers.TD3(lines);
+          if (lines[0].charAt(0) === 'V') {
+            return parsers.MRVA(lines);
+          } else {
+            return parsers.TD3(lines);
+          }
         case 9:
           return parsers.SWISS_DRIVING_LICENSE(lines);
         default:

--- a/src/parse/parsers.js
+++ b/src/parse/parsers.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const parseFrenchNationalId = require('./frenchNationalId');
+const parseMRVA = require('./mrva');
+const parseMRVB = require('./mrvb');
 const parseSwissDrivingLicense = require('./swissDrivingLicense');
 const parseTD1 = require('./td1');
 const parseTD2 = require('./td2');
@@ -12,4 +14,6 @@ module.exports = {
   TD3: parseTD3,
   SWISS_DRIVING_LICENSE: parseSwissDrivingLicense,
   FRENCH_NATIONAL_ID: parseFrenchNationalId,
+  MRVA: parseMRVA,
+  MRVB: parseMRVB,
 };

--- a/src/parsers/parseDocumentCodeVisa.js
+++ b/src/parsers/parseDocumentCodeVisa.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function parseDocumentCodePassport(source) {
+  const first = source.charAt(0);
+  if (first !== 'V') {
+    throw new Error(
+      `invalid document code: ${source}. First character must be V`,
+    );
+  }
+
+  const second = source.charAt(1);
+  if (!second.match(/[A-Z<]/)) {
+    throw new Error(
+      `invalid document code: ${source}. Second character must be a letter or <`,
+    );
+  }
+  if (second === '<') {
+    return {
+      value: first,
+      start: 0,
+      end: 1,
+    };
+  } else {
+    return source;
+  }
+};


### PR DESCRIPTION
Machine Readable Visa is nearly identical to TD3 Passport spec, with some notable exceptions:

- Document code begins with V.  Like TD3, however, the second character of the document code is reserved for the issuing nation's discretion.
- In addition to a 44 character, 2 line spec (MRZ-A) there is also a 36 character, 2 line spec (MRZ-B).  Support for both is added.
- MRV-A and MRV-B do not have a 'Personal Number' field or corresponding check, nor do they have the composite check at the end of line 2
- MRV-A and MRV-B both have an 'Optional Data' field.  ([See here for lengths and positions](https://en.wikipedia.org/wiki/Machine-readable_passport#Machine-readable_visas))


